### PR TITLE
Reformat p1_drainage_area as matrix

### DIFF
--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -2,7 +2,6 @@
 
 
 calc_HITmetrics<-function(data,yearType,drainArea,floodThreshold){
-  drainArea <- drainArea$DA_NWIS
   out_data<- suppressWarnings(calc_allHIT(x=data,yearType=yearType,
                                           drainArea=drainArea,
                                           floodThreshold=floodThreshold))

--- a/_targets.R
+++ b/_targets.R
@@ -65,8 +65,10 @@ p1_flow_metrics<- tar_map(
   
   ###compute all 171 HIT metrics
   tar_target(p1_HIT_metrics,
-             calc_HITmetrics(p1_clean_daily_flow,yearType,drainArea=p1_drainage_area,
-                         floodThreshold=p1_flood_threshold))
+             calc_HITmetrics(p1_clean_daily_flow, 
+                             yearType, 
+                             drainArea = p1_drainage_area$DA_NWIS, 
+                             floodThreshold = p1_flood_threshold))
   
 )
 


### PR DESCRIPTION
#11 

Because we can potentially pull drainage areas from different sources (NWIS, Weickzorek, etc.) I reformatted the target p1_drainage_area to retain site numbers and then add drainage area as a second column (in this case, DA_NWIS). This can be further modified if we want to use the drainage areas based on COMID or another source. The calc_HITmetrics function was modified accordingly to select from the DA_NWIS column (for now). 