### PR TITLE
dynamic branching for data screening

### DIFF
--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -1,11 +1,21 @@
 
+calc_HITmetrics<-function(site_num,clean_daily_flow,yearType,drainArea_tab,floodThreshold_tab){
+  print(site_num)
+  data<- clean_daily_flow %>%
+    filter(site_no == site_num)
 
+  drainArea <- drainArea_tab %>%
+    filter(site_no == site_num)%>%
+    pull(drainArea)
+ 
+  floodThreshold<- floodThreshold_tab %>%
+    filter(site_no == site_num)%>%
+    pull(floodThreshold)
 
-calc_HITmetrics<-function(data,yearType,drainArea,floodThreshold){
   out_data<- suppressWarnings(calc_allHIT(x=data,yearType=yearType,
                                           drainArea=drainArea,
                                           floodThreshold=floodThreshold))
- 
+  
   out_data$site_num<-unique(data$site_no)
   return(out_data)
 }

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,4 +1,25 @@
 
+has_data_check<-function(site_nums,parameterCd){
+  ##check to see if all sites actually have daily flow and peak flow data.  There are
+  ##gages in gagesii that do not have one or the other, so screen these out before we try
+  ##to download the data
+  dv_screen<-whatNWISdata(siteNumber=site_nums,parameterCd=parameterCd,service="dv")
+   pk_screen<-whatNWISdata(siteNumber=site_nums,service="pk")
+  sites_with_data<-intersect(dv_screen$site_no,pk_screen$site_no)
+}
+
+filter_complete_years<-function(screen_daily_flow,complete_years){
+  complete_yr_count<-screen_daily_flow %>% 
+    group_by(site_no)%>%
+    count()
+  keep_sites<-complete_yr_count%>%
+    filter(n >= complete_years)%>%
+    pull(site_no)
+  return(keep_sites)
+}
+
+
+
 get_nwis_daily_data<-function(site_num,outdir,parameterCd,startDate, endDate){
    ##read daily NWIS data, and save to csv file.
   data_out<-readNWISdv(site_num, parameterCd, startDate, endDate)
@@ -19,15 +40,19 @@ get_nwis_peak_data<-function(site_num,outdir,startDate, endDate){
   ## and peak_va is sometimes returned as NA if the gage height is known but not the discharge.
   data_out<-data_out[which(!is.na(data_out$peak_dt)),]
   data_out<-data_out[which(!is.na(data_out$peak_va)),]
-  return(data_out)
+  filepath<-file.path(outdir,paste0(site_num, "_pk.csv"))
+  write_csv(data_out, file=filepath)
+  return(filepath)
+
   
 }
 
 
 screen_daily_data<-function(filename,yearType){
   ##screen for years with missing data
-  data<-read.csv(filename)
+  data<-read_csv(filename)
   data$Date <- as.Date(data$Date)
+  data$site_no <- as.character(data$site_no)
   ###prior to screening, remove any provisional data - this will be counted as 'no data'
   prov_data<- grep('P|e',data$discharge_cd)
   if(length(prov_data)>0){data<-data[-prov_data,]}
@@ -38,35 +63,75 @@ screen_daily_data<-function(filename,yearType){
       water_year_start <- 1
     }
   missing_data<-screen_flow_data(data.frame(site_no=data$site_no, Date=data$Date,Value=data$discharge),water_year_start=water_year_start)
-  missing_data<-data.frame(site_num = unique(data$site_no),missing_data)
-  return(missing_data)
+  complete_yrs<- missing_data %>%
+    filter(n_missing_Q == 0)%>%
+    select(Year)
+  
+
+  if(nrow(complete_yrs) > 0 ){
+   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=complete_yrs$Year)
+  }else {
+   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=0)
+  }
+  
+  return(data_out)
 }
 
 
-clean_daily_data<-function(filename,missing_data, yearType ){
+
+
+clean_daily_data<-function(site,filenames, screen_daily_flow,yearType ){
   ##remove nas from data and remove incomplete years of data
   ##Eflow stats requires the cleaned data to have dates in the first column and 
   ##discharge in the second column.
-  data<-read.csv(filename)
-  data$Date <- as.Date(data$Date)
-  
-  ##remove any missing flow data
-  data<-data[which(!is.na(data$discharge)),]
+  filepath<-filenames[grep(site,filenames)]
+  data<-read_csv(filepath)
+  data$Date<-as_date(data$Date)
+  data$site_no<-as.character(data$site_no)
   data<-addWaterYear(data)
-  
+  print(paste("raw data nrow = ", nrow(data)))
   ##remove all data from years with data gaps
-  keep_years<-missing_data$Year[which(missing_data$n_missing_Q==0)]
+  keep_years<-screen_daily_flow %>%
+    filter(site_no ==site)%>%
+    pull(complete_yrs)
   if (yearType=="water"){
     data_sc<-data[which(data$waterYear %in% keep_years),]
   } else{
-    data_sc<-data[which(year(data$Date)%in% keep_years),]
+    data_sc<-data[which(year(data$date)%in% keep_years),]
   }
+  print(paste("nrow(data_sc", nrow(data_sc)))
   
+  df<-data.frame(as.Date(data_sc$Date),data_sc$discharge)
   ###run EflowStats validation to produce clean, ready to process data
-  clean_data<-validate_data(data_sc[,c("Date","discharge")],yearType=yearType)
+  clean_data<-validate_data(df,yearType=yearType)
   clean_data$site_no<-unique(data_sc$site_no)
+  print(paste("nrow clean_data", nrow(clean_data)))
   return(clean_data)
 }  #end clean_daily_data function
+
+
+get_NWIS_drainArea<-function(site_num){
+  data_out<- data.frame(site_no=as.character(site_num),
+                        drainArea=readNWISsite(siteNumbers=site_num)$drain_area_va)
+  return(data_out)
+}
+
+
+get_floodThreshold<-function(site_num,p1_clean_daily_flow,p1_peak_flow,perc,yearType){
+  
+  df_dv<- p1_clean_daily_flow %>%
+    filter(site_no==site_num)%>%
+    select(date,discharge)
+  
+  filepath<-p1_peak_flow[grep(site_num,p1_peak_flow)]
+  peaks<-read_csv(filepath) 
+  peaks$site_no<-as.character(peaks$site_no)
+  df_pk<-data.frame(date=as.Date(peaks$peak_dt),peak=peaks$peak_va)
+  floodThreshold<-get_peakThreshold(df_dv,df_pk,perc=perc,yearType=yearType)
+  df_out<-data.frame(site_no=site_num,floodThreshold)
+  return(df_out)
+}
+
 
 
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -9,7 +9,9 @@ has_data_check<-function(site_nums,parameterCd){
 }
 
 filter_complete_years<-function(screen_daily_flow,complete_years){
+
   complete_yr_count<-screen_daily_flow %>% 
+    filter(!is.na(complete_yrs))%>%  
     group_by(site_no)%>%
     count()
   keep_sites<-complete_yr_count%>%
@@ -50,9 +52,11 @@ get_nwis_peak_data<-function(site_num,outdir,startDate, endDate){
 
 screen_daily_data<-function(filename,yearType){
   ##screen for years with missing data
-  data<-read_csv(filename)
-  data$Date <- as.Date(data$Date)
-  data$site_no <- as.character(data$site_no)
+  data<-read_csv(filename,
+                 col_types=cols(agency_cd = col_character(),
+                                site_no=col_character(),Date=col_date(format="%Y-%m-%d"),
+                                discharge=col_double(),discharge_cd=col_character()))
+ 
   ###prior to screening, remove any provisional data - this will be counted as 'no data'
   prov_data<- grep('P|e',data$discharge_cd)
   if(length(prov_data)>0){data<-data[-prov_data,]}
@@ -71,7 +75,7 @@ screen_daily_data<-function(filename,yearType){
   if(nrow(complete_yrs) > 0 ){
    data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=complete_yrs$Year)
   }else {
-   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=0)
+   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=NA)
   }
   
   return(data_out)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Repo for machine learning models for regional prediction of hydrologic forcing f
 The package EflowStats can be installed from github using the following lines in R:
 install.packages("remotes")
 remotes::install_github("USGS-R/EflowStats")
+
+note: gages2.1 is currently (As of 12-16-21) being stored in a private repo until it is released to the public.
+

--- a/_targets.R
+++ b/_targets.R
@@ -15,12 +15,12 @@ options(tidyverse.quiet = TRUE)
 ###parameters  
 NWIS_parameter <- '00060'
 startDate<-as.Date("1900-10-01") 
-endDate<-as.Date("2020-9-30")
+endDate<-as.Date("2020-09-30")
 ##water year or calendar year.  I assume we are doing this on water year but
 ##Eflow stats can do either one and it needs to be specified 
 yearType<-"water"
 ##number of complete years we require for a site to be
-complete_years <- 10
+complete_years <- 20
 #precentile for flood threshold in Eflowstats.  0.6 is the default
 perc<-0.6
 

--- a/_targets.R
+++ b/_targets.R
@@ -59,34 +59,34 @@ list(
   tar_target(p1_has_data,
              has_data_check(p1_sites_list,NWIS_parameter)),
  ##fetch daily streamflow
- tar_target(p1_daily_flow, 
+ tar_target(p1_daily_flow_csv, 
              get_nwis_daily_data(p1_has_data,outdir="./1_fetch/out",NWIS_parameter,startDate,endDate),
              map(p1_has_data),
              format="file"),
  ##compute the number of complete years
  tar_target(p1_screen_daily_flow,
-             screen_daily_data(p1_daily_flow,yearType),
-             map(p1_daily_flow)),
+             screen_daily_data(p1_daily_flow_csv,yearType),
+             map(p1_daily_flow_csv)),
   ##select out sites with enough complete years
  tar_target(p1_screened_site_list,
             filter_complete_years(p1_screen_daily_flow,complete_years)),
   ##clean and format daily data so it can be used in eflostats 
  tar_target(p1_clean_daily_flow,
-            clean_daily_data(p1_screened_site_list,p1_daily_flow,p1_screen_daily_flow,yearType),
+            clean_daily_data(p1_screened_site_list,p1_daily_flow_csv,p1_screen_daily_flow,yearType),
             map(p1_screened_site_list)),
  #get drainage area from NWIS
  tar_target(p1_drainage_area,
             get_NWIS_drainArea(p1_screened_site_list),
             map(p1_screened_site_list)),
  ##get and save as file peak flow from NWIS
- tar_target(p1_peak_flow,
+ tar_target(p1_peak_flow_csv,
                get_nwis_peak_data(p1_screened_site_list,outdir="./1_fetch/out",startDate,endDate),
             map(p1_screened_site_list),
             format="file"),
  ##get flood threshold for eflowstats
  tar_target(p1_flood_threshold,
                get_floodThreshold(p1_screened_site_list, p1_clean_daily_flow,
-                                  p1_peak_flow,perc,yearType),
+                                  p1_peak_flow_csv,perc,yearType),
             map(p1_screened_site_list)),
  ##compute all HIT metrics for screened sites list
  tar_target(p1_HIT_metrics,


### PR DESCRIPTION
Changed pipeline to dynamic branching so we could screen out sites with incomplete years of data.  I wasn't sure how to load gagesii from the sharepoint site directly, so there is a link to my local C drive for that file which will have to be changed.  

At the beginning I have some commented out areas where I selected a chunck of sites around CO and another chunk for DE, mostly just to test the pipeline using a bunch of sites to make sure it runs.  There is one site in the CO group - gage 06408700 for which calcHITmetrics fails and I can't figure out why.  I don't think its a targets or our pipeline issue, I think its actually an Eflostats issue, so if you run the CO chunk it will fail there.