### PR TITLE
[27] Added statistics to compute for EflowStats

### DIFF
--- a/1_fetch/src/calc_FDC.R
+++ b/1_fetch/src/calc_FDC.R
@@ -16,6 +16,9 @@ calc_FDCmetrics <- function(site_num, clean_daily_flow, yearType,
   NE_flows <- quantile(data$discharge, probs = NE_probs, type = 6, names = F)
   
   #Compute metrics for each NE_flows threshold
+  #dh, fh, and vh are for duration, frequency, and volume of high flows. 
+  #fdc is for flow-duration curve. 
+  #1 and 2 are two different volume metrics
   dhfdc <- fhfdc <- vhfdc1 <- vhfdc2 <- vector('numeric', length=length(NE_flows))
   for (i in 1:length(NE_flows)){
     #Get the duration of events above each of the NE_flows (dh17 style metrics)

--- a/1_fetch/src/calc_FDC.R
+++ b/1_fetch/src/calc_FDC.R
@@ -1,0 +1,70 @@
+#Function used to compute FDC-based metrics
+calc_FDCmetrics <- function(site_num, clean_daily_flow, yearType, 
+                            drainArea_tab, NE_probs, digits = 3){
+  print(site_num)
+  data <- clean_daily_flow %>%
+    filter(site_no == site_num)
+  
+  drainArea <- drainArea_tab %>%
+    filter(site_no == site_num) %>%
+    pull(drainArea)
+  
+  #Validate using the same function as EflowStats
+  data <- validate_data(data, yearType)
+  
+  #Get the non-exceedance flow values (mh15 style metrics)
+  NE_flows <- quantile(data$discharge, probs = NE_probs, type = 6, names = F)
+  
+  #Compute metrics for each NE_flows threshold
+  dhfdc <- fhfdc <- vhfdc1 <- vhfdc2 <- vector('numeric', length=length(NE_flows))
+  for (i in 1:length(NE_flows)){
+    #Get the duration of events above each of the NE_flows (dh17 style metrics)
+    #We can use the trim=TRUE argument to not count events that start at the 
+    #beginning or end of the record (these have unknown duration)
+    dhfdc[i] <- find_eventDuration(data$discharge, threshold = NE_flows[i], aggType = "average")
+    
+    #Get the number of events above each of the NE_flows (fh5 style metrics)
+    yearlyCounts <- dplyr::do(dplyr::group_by(data, year_val), 
+                              {find_events(.$discharge, 
+                                           threshold = NE_flows[i], type = "high")
+                              })
+    yearlyCounts <- na.omit(yearlyCounts)
+    yearlyCounts <- dplyr::summarize(dplyr::group_by(yearlyCounts, year_val), 
+                                     numEvents = max(event))
+    fhfdc[i] <- mean(yearlyCounts$numEvents)
+    
+    #Get the flow volumes above the NE_flows threshold for events above each of the NE_flows (mh21 style metrics)
+    lst <- find_events(data$discharge, threshold = NE_flows[i])
+    eventData <- na.omit(lst)
+    numEvents <- length(unique(eventData$event))
+    totalFlow <- sum(eventData$flow - NE_flows[i])
+    vhfdc1[i] <- totalFlow/numEvents
+    
+    #Get the average of the max flow for events above each of the NE_flows (mh24 style metrics)
+    eventMax <- dplyr::group_by(lst[c("flow", "event")], event)
+    eventMax <- dplyr::summarize(eventMax, maxQ = max(flow))
+    eventMax <- na.omit(eventMax)
+    vhfdc2[i] <- mean(eventMax$maxQ)
+  }
+  rm(i)
+  
+  #Compile metrics for output data
+  #FDC magnitudes and volumes divided by drainage area
+  #all values rounded
+  mhfdc <- round(NE_flows/drainArea, digits)
+  dhfdc <- round(dhfdc, digits)
+  fhfdc <- round(fhfdc, digits)
+  vhfdc1 <- round(vhfdc1/drainArea, digits)
+  vhfdc2 <- round(vhfdc2/drainArea, digits)
+  
+  #Make a data.frame of values to match the format of the EflowStats metrics
+  out_data <- data.frame(indice = c(paste0('mhfdc_q', NE_probs),
+                                    paste0('dhfdc_q', NE_probs),
+                                    paste0('fhfdc_q', NE_probs),
+                                    paste0('vhfdc1_q', NE_probs),
+                                    paste0('vhfdc2_q', NE_probs)),
+                         statistic = c(mhfdc, dhfdc, fhfdc, vhfdc1, vhfdc2),
+                         site_num = site_num)
+  
+  return(out_data)
+}

--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -1,21 +1,23 @@
-
-calc_HITmetrics<-function(site_num,clean_daily_flow,yearType,drainArea_tab,floodThreshold_tab){
+#Add description
+calc_HITmetrics <- function(site_num, clean_daily_flow, yearType, 
+                            drainArea_tab, floodThreshold_tab, stat_vec){
   print(site_num)
-  data<- clean_daily_flow %>%
+  data <- clean_daily_flow %>%
     filter(site_no == site_num)
 
   drainArea <- drainArea_tab %>%
-    filter(site_no == site_num)%>%
+    filter(site_no == site_num) %>%
     pull(drainArea)
  
-  floodThreshold<- floodThreshold_tab %>%
-    filter(site_no == site_num)%>%
+  floodThreshold <- floodThreshold_tab %>%
+    filter(site_no == site_num) %>%
     pull(floodThreshold)
 
-  out_data<- suppressWarnings(calc_allHIT(x=data,yearType=yearType,
+  out_data <- suppressWarnings(calc_allHIT(x=data, yearType=yearType,
                                           drainArea=drainArea,
-                                          floodThreshold=floodThreshold))
+                                          floodThreshold=floodThreshold, 
+                                          stats = stat_vec))
   
-  out_data$site_num<-unique(data$site_no)
+  out_data$site_num <- unique(data$site_no)
   return(out_data)
 }

--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -35,14 +35,14 @@ calc_HITmetrics <- function(site_num, clean_daily_flow, yearType,
       out_data$statistic[out_data$indice %in% norm_DA]/drainArea, digits)
   }
   
-  #Normalize metrics by median
+  #Normalize metrics by drainage area and remove median normalization
   if (!is.null(norm_med_DA)){
     med_flow <- median(data$discharge, na.rm = TRUE)
     out_data$statistic[out_data$indice %in% norm_med_DA] <- round(
       out_data$statistic[out_data$indice %in% norm_med_DA]/drainArea*med_flow, digits)
   }
   
-  #Normalize ml17 by annual mean and drainage area
+  #Normalize ml17 by drainage area and remove annual mean normalization
   if (!is.null(norm_ml17)){
     calc_bfibyyear <- dplyr::summarize(dplyr::group_by(data, year_val), 
                                        calc_bfi = calc_bfi(discharge)*mean(discharge))

--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -44,6 +44,11 @@ calc_HITmetrics <- function(site_num, clean_daily_flow, yearType,
                                        calc_bfi = calc_bfi(discharge)*mean(discharge))
     
     out_data$statistic[out_data$indice %in% 'ml17'] <- mean(calc_bfibyyear$calc_bfi)/drainArea
+    
+    #Correct the CV of ml18 if it's one of the saved metrics
+    if(!is.null(save_metrics) & ('ml18' %in% save_metrics)){
+      out_data$statistic[out_data$indice %in% 'ml18'] <- sd(calc_bfibyyear$calc_bfi)/mean(calc_bfibyyear$calc_bfi) * 100
+    }
   }
   return(out_data)
 }

--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -1,6 +1,8 @@
 #Add description
 calc_HITmetrics <- function(site_num, clean_daily_flow, yearType, 
-                            drainArea_tab, floodThreshold_tab, stat_vec){
+                            drainArea_tab, floodThreshold_tab, stat_vec,
+                            save_metrics = NULL, norm_DA = NULL, 
+                            norm_med_DA = NULL, norm_ml17 = NULL){
   print(site_num)
   data <- clean_daily_flow %>%
     filter(site_no == site_num)
@@ -19,5 +21,29 @@ calc_HITmetrics <- function(site_num, clean_daily_flow, yearType,
                                           stats = stat_vec))
   
   out_data$site_num <- unique(data$site_no)
+  
+  #Select only the metrics to save
+  if (!is.null(save_metrics)){
+    out_data <- filter(out_data, indice %in% save_metrics)
+  }
+  
+  #Normalize metrics by drainage area
+  if (!is.null(norm_DA)){
+    out_data$statistic[out_data$indice %in% norm_DA] <- out_data$statistic[out_data$indice %in% norm_DA]/drainArea
+  }
+  
+  #Normalize metrics by median
+  if (!is.null(norm_med_DA)){
+    med_flow <- median(data$discharge, na.rm = TRUE)
+    out_data$statistic[out_data$indice %in% norm_med_DA] <- out_data$statistic[out_data$indice %in% norm_med_DA]/drainArea*med_flow
+  }
+  
+  #Normalize ml17 by annual mean and drainage area
+  if (!is.null(norm_ml17)){
+    calc_bfibyyear <- dplyr::summarize(dplyr::group_by(data, year_val), 
+                                       calc_bfi = calc_bfi(discharge)*mean(discharge))
+    
+    out_data$statistic[out_data$indice %in% 'ml17'] <- mean(calc_bfibyyear$calc_bfi)/drainArea
+  }
   return(out_data)
 }

--- a/1_fetch/src/calc_HIT.R
+++ b/1_fetch/src/calc_HIT.R
@@ -31,15 +31,17 @@ calc_HITmetrics <- function(site_num, clean_daily_flow, yearType,
   
   #Normalize metrics by drainage area
   if (!is.null(norm_DA)){
-    out_data$statistic[out_data$indice %in% norm_DA] <- round(
-      out_data$statistic[out_data$indice %in% norm_DA]/drainArea, digits)
+    out_data <- out_data %>% mutate(statistic = case_when(
+      (indice %in% norm_DA) ~ round(statistic/drainArea, digits),
+      TRUE ~ statistic))
   }
   
   #Normalize metrics by drainage area and remove median normalization
   if (!is.null(norm_med_DA)){
     med_flow <- median(data$discharge, na.rm = TRUE)
-    out_data$statistic[out_data$indice %in% norm_med_DA] <- round(
-      out_data$statistic[out_data$indice %in% norm_med_DA]/drainArea*med_flow, digits)
+    out_data <- out_data %>% mutate(statistic = case_when(
+      (indice %in% norm_med_DA) ~ round(statistic/drainArea*med_flow, digits),
+      TRUE ~ statistic))
   }
   
   #Normalize ml17 by drainage area and remove annual mean normalization
@@ -47,13 +49,15 @@ calc_HITmetrics <- function(site_num, clean_daily_flow, yearType,
     calc_bfibyyear <- dplyr::summarize(dplyr::group_by(data, year_val), 
                                        calc_bfi = calc_bfi(discharge)*mean(discharge))
     
-    out_data$statistic[out_data$indice %in% 'ml17'] <- round(
-      mean(calc_bfibyyear$calc_bfi)/drainArea, digits)
+    out_data <- out_data %>% mutate(statistic = case_when(
+      (indice %in% 'ml17') ~ round(mean(calc_bfibyyear$calc_bfi)/drainArea, digits),
+      TRUE ~ statistic))
     
     #Correct the CV of ml18 if it's one of the saved metrics
     if(!is.null(save_metrics) & ('ml18' %in% save_metrics)){
-      out_data$statistic[out_data$indice %in% 'ml18'] <- round(
-        sd(calc_bfibyyear$calc_bfi)/mean(calc_bfibyyear$calc_bfi) * 100, digits)
+      out_data <- out_data %>% mutate(statistic = case_when(
+        (indice %in% 'ml18') ~ round(sd(calc_bfibyyear$calc_bfi)/mean(calc_bfibyyear$calc_bfi) * 100, digits),
+        TRUE ~ statistic))
     }
   }
   return(out_data)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -3,8 +3,8 @@ has_data_check<-function(site_nums,parameterCd){
   ##check to see if all sites actually have daily flow and peak flow data.  There are
   ##gages in gagesii that do not have one or the other, so screen these out before we try
   ##to download the data
-  dv_screen<-whatNWISdata(siteNumber=site_nums,parameterCd=parameterCd,service="dv")
-   pk_screen<-whatNWISdata(siteNumber=site_nums,service="pk")
+  dv_screen<-whatNWISdata(siteNumber=site_nums,parameterCd=parameterCd,service="dv", convertType = FALSE)
+  pk_screen<-whatNWISdata(siteNumber=site_nums,service="pk", convertType = FALSE)
   sites_with_data<-intersect(dv_screen$site_no,pk_screen$site_no)
 }
 
@@ -133,7 +133,7 @@ get_floodThreshold<-function(site_num,p1_clean_daily_flow,p1_peak_flow,perc,year
     select(date,discharge)
   
   filepath<-p1_peak_flow[grep(site_num,p1_peak_flow)]
-  peaks<-read_csv(filepath) 
+  peaks<-read_csv(filepath, show_col_types = FALSE) 
   peaks$site_no<-as.character(peaks$site_no)
   df_pk<-data.frame(date=as.Date(peaks$peak_dt),peak=peaks$peak_va)
   floodThreshold<-get_peakThreshold(df_dv,df_pk,perc=perc,yearType=yearType)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -128,7 +128,7 @@ get_floodThreshold <- function(site_num, p1_clean_daily_flow, p1_peak_flow,
     select(date, discharge)
   
   filepath <- p1_peak_flow[grep(site_num, p1_peak_flow)]
-  peaks <- read_csv(filepath, show_col_types = FALSE) 
+  peaks <- read_csv(filepath, col_types = cols()) 
   peaks$site_no <- as.character(peaks$site_no)
   df_pk <- data.frame(date=as.Date(peaks$peak_dt),peak=peaks$peak_va)
   floodThreshold <- get_peakThreshold(df_dv, df_pk, perc=perc, yearType=yearType)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,160 +1,151 @@
-
-has_data_check<-function(site_nums,parameterCd){
+has_data_check <- function(site_nums, parameterCd){
   ##check to see if all sites actually have daily flow and peak flow data.  There are
   ##gages in gagesii that do not have one or the other, so screen these out before we try
   ##to download the data
-  dv_screen<-whatNWISdata(siteNumber=site_nums,parameterCd=parameterCd,service="dv", convertType = FALSE)
-  pk_screen<-whatNWISdata(siteNumber=site_nums,service="pk", convertType = FALSE)
-  sites_with_data<-intersect(dv_screen$site_no,pk_screen$site_no)
+  dv_screen <- whatNWISdata(siteNumber=site_nums, parameterCd=parameterCd, service="dv",
+                          convertType = FALSE)
+  pk_screen <- whatNWISdata(siteNumber=site_nums, service="pk", convertType = FALSE)
+  sites_with_data <- intersect(dv_screen$site_no, pk_screen$site_no)
 }
 
-filter_complete_years<-function(screen_daily_flow,complete_years){
+filter_complete_years <- function(screen_daily_flow, complete_years){
   
-  complete_yr_count<-screen_daily_flow %>% 
-    filter(!is.na(complete_yrs))%>%  
-    group_by(site_no)%>%
+  complete_yr_count <- screen_daily_flow %>% 
+    filter(!is.na(complete_yrs)) %>%  
+    group_by(site_no) %>%
     count()
   print("complete yr ok")
-  keep_sites<-complete_yr_count%>%
-    filter(n >= complete_years)%>%
+  
+  keep_sites <- complete_yr_count %>%
+    filter(n >= complete_years) %>%
     pull(site_no)
   return(keep_sites)
 }
 
-
-
-get_nwis_daily_data<-function(site_num,outdir,parameterCd,startDate, endDate){
-   print(site_num)
+get_nwis_daily_data <- function(site_num, outdir, parameterCd, startDate, endDate){
+  print(site_num)
   ##read daily NWIS data, and save to csv file.
-  data_out<-readNWISdv(site_num, parameterCd, startDate, endDate)
+  data_out <- readNWISdv(site_num, parameterCd, startDate, endDate)
   ##renaming column names for discharge and discharge_cd
-  names(data_out)[grep(pattern="X_.*\\cd",x=names(data_out))]<-"discharge_cd"
-  names(data_out)[grep(pattern="X_",x=names(data_out))]<-"discharge"
-  filepath<-file.path(outdir,paste0(site_num, "_dv.csv"))
+  names(data_out)[grep(pattern="X_.*\\cd", x=names(data_out))] <- "discharge_cd"
+  names(data_out)[grep(pattern="X_",x=names(data_out))] <- "discharge"
+  filepath <- file.path(outdir, paste0(site_num, "_dv.csv"))
   write_csv(data_out, file=filepath)
   return(filepath)
-  
 }
 
-get_nwis_peak_data<-function(site_num,outdir,startDate, endDate){
+get_nwis_peak_data <- function(site_num, outdir, startDate, endDate){
   print(site_num)
   ##read NWIS peak data, and save to csv file.
-  data_out<-readNWISpeak(site_num,  startDate, endDate)
+  data_out <- readNWISpeak(site_num, startDate, endDate)
   
-  ##Removing any NA dates or peak_va values - dates are returned as NA if day of occurance is not known
+  ##Removing any NA dates or peak_va values - dates are returned as NA if day of occurrence is not known
   ## and peak_va is sometimes returned as NA if the gage height is known but not the discharge.
-  data_out<-data_out[which(!is.na(data_out$peak_dt)),]
-  data_out<-data_out[which(!is.na(data_out$peak_va)),]
-  filepath<-file.path(outdir,paste0(site_num, "_pk.csv"))
+  data_out <- data_out[which(!is.na(data_out$peak_dt)), ]
+  data_out <- data_out[which(!is.na(data_out$peak_va)), ]
+  filepath <- file.path(outdir, paste0(site_num, "_pk.csv"))
   write_csv(data_out, file=filepath)
   return(filepath)
-
-  
 }
 
-
-screen_daily_data<-function(filename,yearType){
+screen_daily_data <- function(filename, yearType){
   ##screen for years with missing data
-  data<-read_csv(filename,
-                 col_types=cols(agency_cd = col_character(),
-                                site_no=col_character(),Date=col_date(format="%Y-%m-%d"),
-                                discharge=col_double(),discharge_cd=col_character()))
+  data <- read_csv(filename,
+                   col_types=cols(agency_cd=col_character(),
+                                  site_no=col_character(), Date=col_date(format="%Y-%m-%d"),
+                                  discharge=col_double(), discharge_cd=col_character()))
  
   ###prior to screening, remove any provisional data - this will be counted as 'no data'
-  prov_data<- grep('P|e',data$discharge_cd)
-  if(length(prov_data)>0){data<-data[-prov_data,]}
+  prov_data <- grep('P|e', data$discharge_cd)
+  if(length(prov_data) > 0){data <- data[-prov_data, ]}
   
   if(yearType=="water"){
-    water_year_start<-10
+    water_year_start <- 10
   }else{
       water_year_start <- 1
-    }
-  missing_data<-screen_flow_data(data.frame(site_no=data$site_no, Date=data$Date,Value=data$discharge),water_year_start=water_year_start)
-  complete_yrs<- missing_data %>%
-    filter(n_missing_Q == 0)%>%
+  }
+  missing_data <- screen_flow_data(data.frame(site_no=data$site_no, 
+                                              Date=data$Date,
+                                              Value=data$discharge),
+                                   water_year_start=water_year_start)
+  complete_yrs <- missing_data %>%
+    filter(n_missing_Q == 0) %>%
     select(Year)
-  
 
-  if(nrow(complete_yrs) > 0 ){
-   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=complete_yrs$Year)
-  }else {
-   data_out<-data.frame(site_no=unique(data$site_no),complete_yrs=NA)
+  if(nrow(complete_yrs) > 0){
+    data_out <- data.frame(site_no=unique(data$site_no),
+                           complete_yrs=complete_yrs$Year)
+  }else{
+    data_out <- data.frame(site_no=unique(data$site_no),
+                           complete_yrs=NA)
   }
   
   return(data_out)
 }
 
-
-
-
-clean_daily_data<-function(site,filenames, screen_daily_flow,yearType ){
-  ##remove nas from data and remove incomplete years of data
-  ##Eflow stats requires the cleaned data to have dates in the first column and 
+clean_daily_data <- function(site, filenames, screen_daily_flow, yearType){
+  ##remove NAs from data and remove incomplete years of data
+  ##EflowStats requires the cleaned data to have dates in the first column and 
   ##discharge in the second column.
   print(site)
-  filepath<-filenames[grep(site,filenames)]
-  data<-read_csv(filepath,
-                 col_types=cols(agency_cd=col_character(),
-                                site_no=col_character(),
-                                Date=col_date(format="%Y-%m-%d"),
-                                discharge=col_double(),
-                                discharge_cd=col_character()))
-  data<-addWaterYear(data)
+  filepath <- filenames[grep(site, filenames)]
+  data <- read_csv(filepath,
+                   col_types=cols(agency_cd=col_character(),
+                                  site_no=col_character(),
+                                  Date=col_date(format="%Y-%m-%d"),
+                                  discharge=col_double(),
+                                  discharge_cd=col_character()))
+  data <- addWaterYear(data)
   ##remove all data from years with data gaps
-  keep_years<-screen_daily_flow %>%
-    filter(site_no ==site)%>%
+  keep_years <- screen_daily_flow %>%
+    filter(site_no == site) %>%
     pull(complete_yrs)
-  if (yearType=="water"){
-    data_sc<-data[which(data$waterYear %in% keep_years),]
-  } else{
-    data_sc<-data[which(year(data$Date)%in% keep_years),]
+  if (yearType == "water"){
+    data_sc <- data[which(data$waterYear %in% keep_years), ]
+  }else{
+    data_sc <- data[which(year(data$Date) %in% keep_years), ]
   }
-
-  df<-data.frame(date=as.Date(data_sc$Date),discharge=data_sc$discharge)
+  
+  df <- data.frame(date=as.Date(data_sc$Date), discharge=data_sc$discharge)
   ###run EflowStats validation to produce clean, ready to process data
-  clean_data<-validate_data(df,yearType=yearType)
-  clean_data$site_no<-unique(data_sc$site_no)
+  clean_data <- validate_data(df, yearType=yearType)
+  clean_data$site_no <- unique(data_sc$site_no)
   return(clean_data)
-}  #end clean_daily_data function
+}#end clean_daily_data function
 
-
-get_NWIS_drainArea<-function(site_num){
+get_NWIS_drainArea <- function(site_num){
   print(site_num)
-  data_out<- data.frame(site_no=as.character(site_num),
-                        drainArea=readNWISsite(siteNumbers=site_num)$drain_area_va)
+  data_out <- data.frame(site_no=as.character(site_num),
+                         drainArea=readNWISsite(siteNumbers=site_num)$drain_area_va)
   return(data_out)
 }
 
-
-get_floodThreshold<-function(site_num,p1_clean_daily_flow,p1_peak_flow,perc,yearType){
+get_floodThreshold <- function(site_num, p1_clean_daily_flow, p1_peak_flow, 
+                               perc, yearType){
   print(site_num)
-  df_dv<- p1_clean_daily_flow %>%
-    filter(site_no==site_num)%>%
-    select(date,discharge)
+  df_dv <- p1_clean_daily_flow %>%
+    filter(site_no == site_num) %>%
+    select(date, discharge)
   
-  filepath<-p1_peak_flow[grep(site_num,p1_peak_flow)]
-  peaks<-read_csv(filepath, show_col_types = FALSE) 
-  peaks$site_no<-as.character(peaks$site_no)
-  df_pk<-data.frame(date=as.Date(peaks$peak_dt),peak=peaks$peak_va)
-  floodThreshold<-get_peakThreshold(df_dv,df_pk,perc=perc,yearType=yearType)
-  df_out<-data.frame(site_no=site_num,floodThreshold)
+  filepath <- p1_peak_flow[grep(site_num, p1_peak_flow)]
+  peaks <- read_csv(filepath, show_col_types = FALSE) 
+  peaks$site_no <- as.character(peaks$site_no)
+  df_pk <- data.frame(date=as.Date(peaks$peak_dt),peak=peaks$peak_va)
+  floodThreshold <- get_peakThreshold(df_dv, df_pk, perc=perc, yearType=yearType)
+  df_out <- data.frame(site_no=site_num, floodThreshold)
   return(df_out)
 }
 
-
-
-
-calc_water_year<-function(dates){
-  water_year <- ifelse(month(dates) > 9, year(dates)+1,year(dates) )
+calc_water_year <- function(dates){
+  water_year <- ifelse(month(dates) > 9, year(dates)+1, year(dates))
   return(water_year)
- 
 } #end calc_water_year
 
+#[Jared] we could use this function to reformat the p1_HIT_metrics. Example:
+# tar_load(p1_HIT_metrics)
+# pivot_wider(data = p1_HIT_metrics, names_from = 'indice', values_from = 'statistic')
 combine_flow_metrics <- function(...) {
   flow_metrics_all_sites <- bind_rows(...) %>%
     pivot_wider(names_from = indice, values_from = statistic)
   return(flow_metrics_all_sites)
 }
-
-
-

--- a/_targets.R
+++ b/_targets.R
@@ -32,7 +32,7 @@ stats_HIT <- c("calc_magAverage", "calc_magLow", "calc_magHigh",
 metrics <- c('ma1', 'ma2', 
              'ml17', 'ml18', 
              'mh15', 'mh16', 'mh17', 'mh20', 'mh21', 'mh24', 'mh27', 
-             'fh1', 'fh2', 'fh5', 'fh8', 
+             'fh1', 'fh2', 'fh5', 
              'dh1', 'dh6', 'dh15', 'dh16', 'dh17', 'dh20',
              'ra1', 'ra2', 'ra3', 'ra4'
 )

--- a/_targets.R
+++ b/_targets.R
@@ -1,98 +1,110 @@
 library(targets)
 library(tarchetypes)
 library(readxl)
-
-dir.create('1_fetch/out',showWarnings=FALSE)
-source("./1_fetch/src/get_nwis_data.R")
-source("./1_fetch/src/calc_HIT.R")
-
-tar_option_set(packages = c("fasstr","EflowStats","dataRetrieval",
-                            "lubridate"))
 suppressPackageStartupMessages(library(tidyverse))
 options(tidyverse.quiet = TRUE)
 
+##Load libraries for use in computing targets
+tar_option_set(packages = c("fasstr", "EflowStats", "dataRetrieval",
+                            "lubridate"))
 
-###parameters  
+##Create output file directories
+dir.create('1_fetch/out', showWarnings=FALSE)
+
+##Load user defined functions
+source("./1_fetch/src/get_nwis_data.R")
+source("./1_fetch/src/calc_HIT.R")
+
+###Define parameters
 NWIS_parameter <- '00060'
-startDate<-as.Date("1900-10-01") 
-endDate<-as.Date("2020-09-30")
-##water year or calendar year.  I assume we are doing this on water year but
-##Eflow stats can do either one and it needs to be specified 
-yearType<-"water"
-##number of complete years we require for a site to be
+startDate <- as.Date("1900-10-01") 
+endDate <- as.Date("2020-09-30")
+##water year or calendar year.
+yearType <- "water"
+##number of complete years we require for a site to be used
 complete_years <- 20
-#precentile for flood threshold in Eflowstats.  0.6 is the default
-perc<-0.6
+##percentile for flood threshold in EflowStats. 0.6 is the default
+perc <- 0.6
+##statistics to compute within EflowStats
+stats_HIT <- c("calc_magAverage", "calc_magLow", "calc_magHigh", 
+               "calc_frequencyHigh", "calc_durationHigh", "calc_rateChange")
 
 ###gages2.1 ref site list - not sure how to get this right from sharepoint, so the
-##filepath is currently to my onedrive.
-gagesii_path<-"C:/Users/slevin/OneDrive - DOI/FWA_bridgeScour/Data/Gages2.1_RefSiteList.xlsx"
-gagesii<-read_xlsx(gagesii_path)
-gagesii$ID<- substr(gagesii$ID,start=2,stop=nchar(gagesii$ID))
-##
+##filepath is currently to onedrive.
+gagesii_path <- "C:/Users/jsmith/OneDrive - DOI/Shared Documents - FHWA/General/Data/Gages2.1_RefSiteList.xlsx"
+gagesii <- read_xlsx(gagesii_path)
+gagesii$ID <- substr(gagesii$ID, start=2, stop=nchar(gagesii$ID))
+
 
 ## not sure yet how we'll be selecting gages so I'm not putting this in a function yet.
 ##since there is no state attribution in the gagesii list, for East River, I am taking 
 ##AggEco==WestMnts and LON > -117 which cuts off the pacific northwest and cA areas
 
-
-#p1_sites_list<- c("06036805" ,"06036905", "06037500","06043500","06073500","06078500","06090500",
-#"06092500","06109800","06115500" ,"06137570" ,"06154410","06188000","06190540")
-#note- 
-
-#p1_sites_list<-gagesii %>%
-#  filter(AggEco=="WestMnts") %>%
-#  filter(LON > -117)%>%
+#p1_sites_list <- gagesii %>%
+#  filter(AggEco == "WestMnts") %>%
+#  filter(LON > -117) %>%
 #  pull(ID)
 
 ##DE - just pulling a bounding box of sites here
-p1_sites_list<-gagesii %>%
-  filter(LAT<42) %>%
-  filter(LON > -76)%>%
+p1_sites_list <- gagesii %>%
+  filter(LAT < 42) %>%
+  filter(LON > -76) %>%
   pull(ID)
-
 
 
 ##targets
 list(
   ##check to make sure peak and daily flow are actually available for all sites
   tar_target(p1_has_data,
-             has_data_check(p1_sites_list,NWIS_parameter)),
- ##fetch daily streamflow
- tar_target(p1_daily_flow_csv, 
-             get_nwis_daily_data(p1_has_data,outdir="./1_fetch/out",NWIS_parameter,startDate,endDate),
+             has_data_check(p1_sites_list, NWIS_parameter)),
+  
+  ##fetch daily streamflow
+  tar_target(p1_daily_flow_csv, 
+             get_nwis_daily_data(p1_has_data, outdir="./1_fetch/out", 
+                                 NWIS_parameter, startDate, endDate),
              map(p1_has_data),
              format="file"),
- ##compute the number of complete years
- tar_target(p1_screen_daily_flow,
-             screen_daily_data(p1_daily_flow_csv,yearType),
+  
+  ##compute the number of complete years
+  tar_target(p1_screen_daily_flow,
+             screen_daily_data(p1_daily_flow_csv, yearType),
              map(p1_daily_flow_csv)),
+  
   ##select out sites with enough complete years
- tar_target(p1_screened_site_list,
-            filter_complete_years(p1_screen_daily_flow,complete_years)),
+  tar_target(p1_screened_site_list,
+             filter_complete_years(p1_screen_daily_flow, complete_years)),
+  
   ##clean and format daily data so it can be used in eflostats 
- tar_target(p1_clean_daily_flow,
-            clean_daily_data(p1_screened_site_list,p1_daily_flow_csv,p1_screen_daily_flow,yearType),
-            map(p1_screened_site_list)),
- #get drainage area from NWIS
- tar_target(p1_drainage_area,
-            get_NWIS_drainArea(p1_screened_site_list),
-            map(p1_screened_site_list)),
- ##get and save as file peak flow from NWIS
- tar_target(p1_peak_flow_csv,
-               get_nwis_peak_data(p1_screened_site_list,outdir="./1_fetch/out",startDate,endDate),
-            map(p1_screened_site_list),
-            format="file"),
- ##get flood threshold for eflowstats
- tar_target(p1_flood_threshold,
-               get_floodThreshold(p1_screened_site_list, p1_clean_daily_flow,
-                                  p1_peak_flow_csv,perc,yearType),
-            map(p1_screened_site_list)),
- ##compute all HIT metrics for screened sites list
- tar_target(p1_HIT_metrics,
-                 calc_HITmetrics(p1_screened_site_list,p1_clean_daily_flow,yearType,
-                                 drainArea_tab=p1_drainage_area,floodThreshold_tab=p1_flood_threshold),
-            map(p1_screened_site_list)) 
-
- 
+  tar_target(p1_clean_daily_flow,
+             clean_daily_data(p1_screened_site_list, p1_daily_flow_csv, 
+                              p1_screen_daily_flow, yearType),
+             map(p1_screened_site_list)),
+  
+  #get drainage area from NWIS
+  tar_target(p1_drainage_area,
+             get_NWIS_drainArea(p1_screened_site_list),
+             map(p1_screened_site_list)),
+  
+  ##get and save as file peak flow from NWIS
+  tar_target(p1_peak_flow_csv,
+             get_nwis_peak_data(p1_screened_site_list, outdir="./1_fetch/out",
+                                startDate, endDate),
+             map(p1_screened_site_list),
+             format="file"),
+  
+  ##get flood threshold for eflowstats
+  tar_target(p1_flood_threshold,
+             get_floodThreshold(p1_screened_site_list, p1_clean_daily_flow,
+                                p1_peak_flow_csv, perc, yearType),
+             map(p1_screened_site_list)),
+  
+  ##compute all HIT metrics for screened sites list
+  tar_target(p1_HIT_metrics,
+             calc_HITmetrics(site_num = p1_screened_site_list, 
+                             clean_daily_flow = p1_clean_daily_flow, 
+                             yearType = yearType,
+                             drainArea_tab = p1_drainage_area,
+                             floodThreshold_tab = p1_flood_threshold,
+                             stat_vec = stats_HIT),
+             map(p1_screened_site_list)) 
 ) #end list

--- a/_targets.R
+++ b/_targets.R
@@ -28,6 +28,17 @@ perc <- 0.6
 ##statistics to compute within EflowStats
 stats_HIT <- c("calc_magAverage", "calc_magLow", "calc_magHigh", 
                "calc_frequencyHigh", "calc_durationHigh", "calc_rateChange")
+##EflowStats metrics to use
+metrics <- c('ma1', 'ma2', 'ml17', 'ml18', 'mh15', 'mh16', 'mh17', 
+             'mh20', 'mh21', 'mh24', 'mh27', 'fh1', 'fh2', 'fh5', 'fh8', 
+             'dh1', 'dh6', 'dh15', 'dh16', 'dh17', 'ra1', 'ra2', 'ra3', 'ra4'
+)
+##metrics to normalize by drainage area
+metrics_DA <- c('ma1', 'ma2', 'dh1', 'ra1', 'ra3')
+##metric ml17 to normalize by *annual mean/drainage area
+metrics_ml17 <- c('ml17')
+##metrics to normalize by *median/drainage area
+metrics_med_DA <- c('mh15', 'mh16', 'mh17', 'mh21', 'mh24', 'mh27')
 
 ###gages2.1 ref site list - not sure how to get this right from sharepoint, so the
 ##filepath is currently to onedrive.
@@ -105,6 +116,10 @@ list(
                              yearType = yearType,
                              drainArea_tab = p1_drainage_area,
                              floodThreshold_tab = p1_flood_threshold,
-                             stat_vec = stats_HIT),
+                             stat_vec = stats_HIT,
+                             save_metrics = metrics,
+                             norm_DA = metrics_DA,
+                             norm_med_DA = metrics_med_DA,
+                             norm_ml17 = metrics_ml17),
              map(p1_screened_site_list)) 
 ) #end list

--- a/_targets.R
+++ b/_targets.R
@@ -124,5 +124,5 @@ list(
                              norm_DA = metrics_DA,
                              norm_med_DA = metrics_med_DA,
                              norm_ml17 = metrics_ml17),
-             map(p1_screened_site_list)) 
+             map(p1_screened_site_list))
 ) #end list

--- a/_targets.R
+++ b/_targets.R
@@ -29,9 +29,12 @@ perc <- 0.6
 stats_HIT <- c("calc_magAverage", "calc_magLow", "calc_magHigh", 
                "calc_frequencyHigh", "calc_durationHigh", "calc_rateChange")
 ##EflowStats metrics to use
-metrics <- c('ma1', 'ma2', 'ml17', 'ml18', 'mh15', 'mh16', 'mh17', 
-             'mh20', 'mh21', 'mh24', 'mh27', 'fh1', 'fh2', 'fh5', 'fh8', 
-             'dh1', 'dh6', 'dh15', 'dh16', 'dh17', 'ra1', 'ra2', 'ra3', 'ra4'
+metrics <- c('ma1', 'ma2', 
+             'ml17', 'ml18', 
+             'mh15', 'mh16', 'mh17', 'mh20', 'mh21', 'mh24', 'mh27', 
+             'fh1', 'fh2', 'fh5', 'fh8', 
+             'dh1', 'dh6', 'dh15', 'dh16', 'dh17', 'dh20',
+             'ra1', 'ra2', 'ra3', 'ra4'
 )
 ##metrics to normalize by drainage area
 metrics_DA <- c('ma1', 'ma2', 'dh1', 'ra1', 'ra3')
@@ -85,7 +88,7 @@ list(
   tar_target(p1_screened_site_list,
              filter_complete_years(p1_screen_daily_flow, complete_years)),
   
-  ##clean and format daily data so it can be used in eflostats 
+  ##clean and format daily data so it can be used in EflowStats 
   tar_target(p1_clean_daily_flow,
              clean_daily_data(p1_screened_site_list, p1_daily_flow_csv, 
                               p1_screen_daily_flow, yearType),


### PR DESCRIPTION
This PR reduces the number of statistics computed by EflowStats. The `stats_HIT` vector in `_targets.R` specifies the functions used by EflowStats. This will solve the problem in #27, but I'm not closing that issue with this PR because of the ongoing discussion.

The most recent commit further reduces the metrics to only those we will use for the project. It also implements drainage area normalization, and removes the median and annual mean normalization used for some metrics

There are also style changes to the 3 R scripts (spaces, indentations, white space).