### PR TITLE
55 cluster diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ _targets
 #Clustermq worker log files
 *.log
 
+#R plots
+Rplots.pdf
+
 # History files
 .Rhistory
 .Rapp.history

--- a/3_cluster/src/seasonal_metric_cluster.R
+++ b/3_cluster/src/seasonal_metric_cluster.R
@@ -83,7 +83,10 @@ compute_cluster_diagnostics <- function(clusts, metric_mat,
                                hc_func = 'hclust', hc_method = clust_method,
                                hc_metric = dist_method, verbose = FALSE)
   
-  return(list(nbclust_metrics = nbclust_metrics, gap_stat = gap_stat))
+  return(list(flow_metric = clusts$metric, 
+              #dropping the suggested best cluster partition to save space
+              nbclust_metrics = nbclust_metrics[-4], 
+              gap_stat = gap_stat))
 }
 
 #Function to make cluster diagnostic panel plot
@@ -114,7 +117,7 @@ plot_cluster_diagnostics <- function(clusts, metric_mat, nbclust_metrics,
                           ',\nCluster Method: ', clust_method))
     
     #histogram of optimal number of clusters
-    p3 <- ggplot(data = as.data.frame(t(nbclust_metrics$clusts$Best.nc)), 
+    p3 <- ggplot(data = as.data.frame(t(nbclust_metrics$nbclust_metrics$Best.nc)), 
                  aes(Number_clusters)) + 
       geom_histogram(bins = 20, binwidth = 0.5) +
       labs(title = paste0('Suggested Optimal Number of Clusters from 26 Metrics\nMetric: ', 

--- a/_targets.R
+++ b/_targets.R
@@ -376,7 +376,7 @@ list(
                                       dist_method = 'euclidean',
                                       clust_method = 'ward.D2',
                                       dir_out = '3_cluster/out/seasonal_plots/diagnostics/'),
-             map(p3_FDC_clusters),
+             map(p3_FDC_clusters, p3_FDC_cluster_diagnostics),
              deployment = 'worker',
              format = 'file'),
   

--- a/_targets.R
+++ b/_targets.R
@@ -476,12 +476,12 @@ list(
              map(p3_cluster_cols),
              deployment = 'worker',
              format = "file"
-  #),
+  ),
   
-  #matrix of nested gages - 1 if column name gage is upstream of the row name gage, 0 otherwise
-  #tar_target(p4_nested_gages,
-  #           get_nested_gages(gagesii = p1_sites_g2,
-  #                            nav_distance_km = nav_distance_km,
-  #            deployment = 'worker')
+  #matrix of nested gages - proportion of overlapping area if column name gage is upstream of the row name gage, 0 otherwise
+  tar_target(p4_nested_gages,
+             get_nested_gages(gagesii = p1_sites_g2,
+                              nav_distance_km = nav_distance_km),
+             deployment = 'worker'
             )  
 ) #end list


### PR DESCRIPTION
This PR adds a function to compute 26 NbClust cluster diagnostic metrics. I also moved the computation of the gap statistic (27th metric) out of the plotting function and into this function. The function saves the diagnostics to a target that we can access them for reference later. 

Note that it takes a long time to compute these diagnostics for all metrics, so it's probably best to evaluate this PR for just one of them using something like `tar_make(p3_FDC_cluster_diagnostics_e309a6a3)`. For reference if you want to try building in parallel with `tar_make_clustermq`, it used about 0.5 GB of RAM per worker, and each set of diagnostics took about 5 minutes to compute.


This PR also updates the diagnostic panel plot by replacing the silhouette distance metric plot with a histogram of the optimal number of clusters suggested from these 26 metrics.

Closes #55 