### PR TITLE
Monthly avg weather

### DIFF
--- a/1_fetch/src/get_sb_data.R
+++ b/1_fetch/src/get_sb_data.R
@@ -219,8 +219,9 @@ download_children <-function(sites, sb_table_reduced, dldir, workdir, outdir, ou
   return(return_df)
 }
 
-calc_avg_monthly_weather <- function(sb_data, arg2) {
-  sb_data <- read_csv(sb_data[[1]], show_col_types = FALSE)
+calc_avg_monthly_weather <- function(sb_data) {
+  sb_data <- read_csv(sb_data, show_col_types = FALSE) %>%
+    suppressMessages()
   precip <- sb_data %>%
     select(COMID, contains("_PPT_")) %>%
     pivot_longer(!COMID, names_to = "unit_month_year", values_to = "precip") %>%
@@ -256,4 +257,5 @@ calc_avg_monthly_weather <- function(sb_data, arg2) {
     select(COMID, name, avg_monthly_temp) %>%
     pivot_wider(names_from = "name", values_from = "avg_monthly_temp")
   weather <- left_join(precip, temperature, by = "COMID")
+  return(weather)
 }

--- a/1_fetch/src/get_sb_data.R
+++ b/1_fetch/src/get_sb_data.R
@@ -222,40 +222,23 @@ download_children <-function(sites, sb_table_reduced, dldir, workdir, outdir, ou
 calc_avg_monthly_weather <- function(sb_data) {
   sb_data <- read_csv(sb_data, show_col_types = FALSE) %>%
     suppressMessages()
-  precip <- sb_data %>%
-    select(COMID, contains("_PPT_")) %>%
-    pivot_longer(!COMID, names_to = "unit_month_year", values_to = "precip") %>%
-    mutate(unit = str_sub(unit_month_year, 1, 3), 
-           month_name = str_sub(unit_month_year, 9, 11)) %>%
-    group_by(COMID, unit, month_name) %>%
-    summarise(avg_monthly_ppt = mean(precip, na.rm = TRUE), .groups = "drop") %>%
+  weather <- sb_data %>%
+    select(COMID, contains("_PPT_"), contains("_TAV_")) %>%
+    pivot_longer(!COMID, names_to = "name", values_to = "value") %>%
+    mutate(unit = str_sub(name, 1, 3), 
+           type = str_sub(name, 5, 7),
+           month_name = str_sub(name, 9, 11)) %>%
+    group_by(COMID, unit, type, month_name) %>%
+    summarise(avg_monthly = mean(value, na.rm = TRUE), .groups = "drop") %>%
     mutate(month_num = case_when(month_name == "JAN" ~ 1, month_name == "FEB" ~ 2, 
                                  month_name == "MAR" ~ 3, month_name == "APR" ~ 4, 
                                  month_name == "MAY" ~ 5, month_name == "JUN" ~ 6, 
                                  month_name == "JUL" ~ 7, month_name == "AUG" ~ 8, 
                                  month_name == "SEP" ~ 9, month_name == "OCT" ~ 10, 
                                  month_name == "NOV" ~ 11, month_name == "DEC" ~ 12),
-           name = paste0(unit, "_PPT_", month_name)) %>%
-    arrange(COMID, unit, month_num) %>%
-    select(COMID, name, avg_monthly_ppt) %>%
-    pivot_wider(names_from = "name", values_from = "avg_monthly_ppt")
-  temperature <- sb_data %>%
-    select(COMID, contains("_TAV_")) %>%
-    pivot_longer(!COMID, names_to = "unit_month_year", values_to = "temp") %>%
-    mutate(unit = str_sub(unit_month_year, 1, 3), 
-           month_name = str_sub(unit_month_year, 9, 11)) %>%
-    group_by(COMID, unit, month_name) %>%
-    summarise(avg_monthly_temp = mean(temp, na.rm = TRUE), .groups = "drop") %>%
-    mutate(month_num = case_when(month_name == "JAN" ~ 1, month_name == "FEB" ~ 2, 
-                                 month_name == "MAR" ~ 3, month_name == "APR" ~ 4, 
-                                 month_name == "MAY" ~ 5, month_name == "JUN" ~ 6, 
-                                 month_name == "JUL" ~ 7, month_name == "AUG" ~ 8, 
-                                 month_name == "SEP" ~ 9, month_name == "OCT" ~ 10, 
-                                 month_name == "NOV" ~ 11, month_name == "DEC" ~ 12),
-           name = paste0(unit, "_TAV_", month_name)) %>%
-    arrange(COMID, unit, month_num) %>%
-    select(COMID, name, avg_monthly_temp) %>%
-    pivot_wider(names_from = "name", values_from = "avg_monthly_temp")
-  weather <- left_join(precip, temperature, by = "COMID")
+           label = paste0(unit, "_", type, "_", month_name)) %>%
+    arrange(COMID, type, unit, month_num) %>%
+    select(COMID, label, avg_monthly) %>%
+    pivot_wider(names_from = "label", values_from = "avg_monthly")
   return(weather)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -306,6 +306,12 @@ list(
              format = "file"
              ),
   
+  ##convert monthly weather data by year to average monthly weather
+  tar_target(p1_monthly_weather_g2, 
+             calc_avg_monthly_weather(sb_data = p1_sb_data_g2_csv[[1]]), 
+             deployment = 'main', 
+             ),
+  
   ##get flood threshold from NWIS for eflowstats
   #this is deployed on main to avoid overloading the NWIS server with download requests
   tar_target(p1_flood_threshold,

--- a/_targets.R
+++ b/_targets.R
@@ -308,7 +308,9 @@ list(
   
   ##convert monthly weather data by year to average monthly weather
   tar_target(p1_monthly_weather_g2, 
-             calc_avg_monthly_weather(sb_data = p1_sb_data_g2_csv[[1]]), 
+             {file_ind <- grep(p1_sb_data_g2_csv, pattern = "FAILS", invert = TRUE)
+               calc_avg_monthly_weather(sb_data = p1_sb_data_g2_csv[file_ind])
+             }, 
              deployment = 'main', 
              ),
   


### PR DESCRIPTION
Since target 'p1_sb_data_g2_csv' has two filepaths (one for the actual data frame, another listing fails from sb download and merge) I had to specify the input for this target as 'p1_sb_data_g2_csv[[1]]'. It works, but I'm not sure if it is a _best practice_. If you don't like this, I could edit target 'p1_sb_data_g2_csv' to only return a single data frame, then the list of fails would be a separate target(?). Let me know what you think.