### PR TITLE
82 avg wildfire

### DIFF
--- a/1_fetch/src/get_sb_data.R
+++ b/1_fetch/src/get_sb_data.R
@@ -242,3 +242,20 @@ calc_avg_monthly_weather <- function(sb_data) {
     pivot_wider(names_from = "label", values_from = "avg_monthly")
   return(weather)
 }
+
+calc_avg_wildfire <- function(sb_data) {
+  sb_data <- read_csv(sb_data, show_col_types = FALSE) %>%
+    suppressMessages()
+  wildfire <- sb_data %>%
+    select(COMID, contains("_WILDFIRE_")) %>%
+    pivot_longer(!COMID, names_to = "name", values_to = "value") %>%
+    mutate(unit = str_sub(name, 1, 3), 
+           year = str_sub(name, 14, 17)) %>%
+    group_by(COMID, unit) %>%
+    summarise(avg_annual = mean(value, na.rm = TRUE), .groups = "drop") %>%
+    mutate(label = paste0(unit, "_AVG_WILDFIRE")) %>%
+    arrange(COMID, label) %>%
+    select(COMID, label, avg_annual) %>%
+    pivot_wider(names_from = "label", values_from = "avg_annual")
+  return(wildfire)
+}

--- a/_targets.R
+++ b/_targets.R
@@ -314,6 +314,14 @@ list(
              deployment = 'main', 
              ),
   
+  ##convert annual wildfire data to long-term average wildfire
+  tar_target(p1_avg_wildfire_g2, 
+             {file_ind <- grep(p1_sb_data_g2_csv, pattern = "FAILS", invert = TRUE)
+             calc_avg_wildfire(sb_data = p1_sb_data_g2_csv[file_ind])
+             }, 
+             deployment = 'main', 
+  ),
+  
   ##get flood threshold from NWIS for eflowstats
   #this is deployed on main to avoid overloading the NWIS server with download requests
   tar_target(p1_flood_threshold,


### PR DESCRIPTION
Averaging percentages is not ideal - for instance, 11 of the years could have 0% burn, one year could have 100% burn, and the average value (what is computed here) is 8.33%. While I believe this metric still describes which catchments/watersheds were more susceptible to wildfires from 2000 to 2012, the value itself has lost some meaning and the unit is convoluted. Likely not an issue for modeling purposes, might be annoying when describing metadata.  
