### PR TITLE
added imports of packages 

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -10,7 +10,11 @@ library(tidyverse)
 tar_option_set(packages = c("fasstr", "EflowStats", "dataRetrieval",
                             "lubridate", "cluster", "factoextra", "NbClust",
                             "sf", "cowplot", "gridGraphics", "stringi",
-                            "dendextend", "scico", "tidyverse", "nhdplusTools","sbtools"))
+                            "dendextend", "scico", "tidyverse", "nhdplusTools",
+                            "sbtools"),
+               imports = c("fasstr", "EflowStats", "dataRetrieval", 
+                           "cluster","factoextra", "NbClust", "dendextend",
+                           "tidyverse"))
 
 ##Create output file directories
 dir.create('1_fetch/out', showWarnings = FALSE)


### PR DESCRIPTION
I added the packages to the targets `imports` argument to track changes in the functions in these packages. There were several packages that resulted in an error when building the pipeline, and therefore could not be tracked. 

For the other packages, I verified that these functions are tracked by looking at the tar_visnetwork. It has a very long tail of functions from the packages (the ones we do not use in our pipeline).
![image](https://user-images.githubusercontent.com/8761242/163597250-68577082-190b-42c7-8041-d9ac2d127297.png)

I think `tar_glimpse` will now be a more useful way to visualize the pipeline connections:
![image](https://user-images.githubusercontent.com/8761242/163597388-0322b00d-6b27-4614-90b4-aa51236a876b.png)

Closes #72 