### PR TITLE
add scripts to transfer _targets and out files

### DIFF
--- a/slurm/transfer_targets_fork_main.slurm
+++ b/slurm/transfer_targets_fork_main.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=tar_transfer         # human-readable label for squeue output
-#SBATCH --time=1:00:00                  # maximum time for this job
+#SBATCH --time=12:00:00                  # maximum time for this job
 #SBATCH --output=tar_transfer_%u.out    # user's output file
 #SBATCH --partition=cpu                 # which SLURM partition to use
 #SBATCH --nodes=1                       # only request one node
@@ -40,7 +40,16 @@ fi
 rsync -a "$1"'/_targets' $USGS_DIR
 
 #copy output files (using rsync to copy only new files or updated files)
-rsync -a "$1"'/1_fetch/out' $USGS_DIR'1_fetch/'
-rsync -a "$1"'/3_cluster/out' $USGS_DIR'3_cluster/'
-rsync -a "$1"'/5_EDA/out' $USGS_DIR'5_EDA/'
-rsync -a "$1"'/6_predict/out' $USGS_DIR'6_predict/'
+#Gather all folder names with a /out directory. The last grep remove any files (. for file extension)
+cd $1
+SYNC_DIRS=$(ls | grep -E '[0-9]+_' | grep -Fv '.')
+for dir in $SYNC_DIRS
+do
+    #Check that this directory has an /out subdirectory
+    OUT_CHECK=$(ls "$1"/$dir/ | grep -E 'out')
+    if [ ! -z $OUT_CHECK ]
+    then
+        #sync files
+        rsync -a "$1"/$dir/'out' $USGS_DIR$dir/
+    fi
+done

--- a/slurm/transfer_targets_fork_main.slurm
+++ b/slurm/transfer_targets_fork_main.slurm
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=tar_transfer         # human-readable label for squeue output
 #SBATCH --time=12:00:00                  # maximum time for this job
-#SBATCH --output=tar_transfer_%u.out    # user's output file
+#SBATCH --output=tar_transfer_fork_main_%u.out    # user's output file
 #SBATCH --partition=cpu                 # which SLURM partition to use
 #SBATCH --nodes=1                       # only request one node
 #SBATCH --ntasks=1                      # only request one core

--- a/slurm/transfer_targets_fork_main.slurm
+++ b/slurm/transfer_targets_fork_main.slurm
@@ -1,0 +1,46 @@
+#!/bin/bash
+#SBATCH --job-name=tar_transfer         # human-readable label for squeue output
+#SBATCH --time=1:00:00                  # maximum time for this job
+#SBATCH --output=tar_transfer_%u.out    # user's output file
+#SBATCH --partition=cpu                 # which SLURM partition to use
+#SBATCH --nodes=1                       # only request one node
+#SBATCH --ntasks=1                      # only request one core
+#SBATCH --mail-type=ALL                 # enable email notifications for job status. Sends to submitting user
+#SBATCH -A fhwa                         # project account to charge
+
+################################################################################
+#This script syncs the _targets folder and output fles from a forked copy of the repo to the
+#USGS-R/main copy of the repo located at /caldera/projects/usgs/water/impd/fhwa/regional-hydrologic-forcings-ml/
+
+#The directory of the forked repo should be supplied in the sbatch command
+#Example:
+# sbatch --mail-user=<user>@usgs.gov transfer_targets_fork_main.slurm /path/to/user/fork/of/regional-hydrologic-forcings-ml/
+
+#The intended use is to get targets and file data up to date after a PR is merged.
+#Remember to also update the USGS-R/main code with git pull
+################################################################################
+
+module purge
+
+USGS_DIR='/caldera/projects/usgs/water/impd/fhwa/regional-hydrologic-forcings-ml/'
+
+#Checks that the destination target objects are not newer than the newest objects in the source
+#Exits and does not transfer files if they are newer.
+cd $USGS_DIR/'_targets/objects'
+NEWEST_USGS_OBJECT=$(ls -t | head -n1)
+cd $1/'_targets/objects'
+NEWEST_FORK_OBJECT=$(ls -t | head -n1)
+if [ $USGS_DIR'_targets/objects'/$NEWEST_USGS_OBJECT -nt $1/'_targets/objects'/$NEWEST_FORK_OBJECT ]
+then
+    printf '%s\n' "$USGS_DIR has files that are newer than $1 so files are not being copied."
+    exit 1
+fi
+
+#copy _targets folder (using rsync to copy only new targets or updated targets)
+rsync -a "$1"'/_targets' $USGS_DIR
+
+#copy output files (using rsync to copy only new files or updated files)
+rsync -a "$1"'/1_fetch/out' $USGS_DIR'1_fetch/'
+rsync -a "$1"'/3_cluster/out' $USGS_DIR'3_cluster/'
+rsync -a "$1"'/5_EDA/out' $USGS_DIR'5_EDA/'
+rsync -a "$1"'/6_predict/out' $USGS_DIR'6_predict/'

--- a/slurm/transfer_targets_main_fork.slurm
+++ b/slurm/transfer_targets_main_fork.slurm
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=tar_transfer         # human-readable label for squeue output
 #SBATCH --time=1:00:00                  # maximum time for this job
-#SBATCH --output=tar_transfer_%u.out    # user's output file
+#SBATCH --output=tar_transfer_main_fork_%u.out    # user's output file
 #SBATCH --partition=cpu                 # which SLURM partition to use
 #SBATCH --nodes=1                       # only request one node
 #SBATCH --ntasks=1                      # only request one core

--- a/slurm/transfer_targets_main_fork.slurm
+++ b/slurm/transfer_targets_main_fork.slurm
@@ -41,7 +41,16 @@ fi
 rsync -a $USGS_DIR'/_targets' "$1"
 
 #copy output files (using rsync to copy only new files or updated files)
-rsync -a "$USGS_DIR"'1_fetch/out' $1'/1_fetch/'
-rsync -a "$USGS_DIR"'3_cluster/out' $1'/3_cluster/'
-rsync -a "$USGS_DIR"'5_EDA/out' $1'/5_EDA/'
-rsync -a "$USGS_DIR"'6_predict/out' $1'/6_predict/'
+#Gather all folder names with a /out directory. The last grep remove any files (. for file extension)
+cd $USGS_DIR
+SYNC_DIRS=$(ls | grep -E '[0-9]+_' | grep -Fv '.')
+for dir in $SYNC_DIRS
+do
+    #Check that this directory has an /out subdirectory
+    OUT_CHECK=$(ls "$USGS_DIR"$dir/ | grep -E 'out')
+    if [ ! -z $OUT_CHECK ]
+    then
+        #sync files
+        rsync -a "$USGS_DIR"$dir/'out' $1/$dir/
+    fi
+done

--- a/slurm/transfer_targets_main_fork.slurm
+++ b/slurm/transfer_targets_main_fork.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=tar_transfer         # human-readable label for squeue output
+#SBATCH --time=1:00:00                  # maximum time for this job
+#SBATCH --output=tar_transfer_%u.out    # user's output file
+#SBATCH --partition=cpu                 # which SLURM partition to use
+#SBATCH --nodes=1                       # only request one node
+#SBATCH --ntasks=1                      # only request one core
+#SBATCH --mail-type=ALL                 # enable email notifications for job status. Sends to submitting user
+#SBATCH -A fhwa                         # project account to charge
+
+################################################################################
+#This script syncs the _targets folder and output files from the USGS-R/main copy of the repo 
+#located at /caldera/projects/usgs/water/impd/fhwa/regional-hydrologic-forcings-ml/
+#to a forked copy of the repo
+
+#The directory of the forked repo should be supplied in the sbatch command
+#Example:
+# sbatch --mail-user=<user>@usgs.gov transfer_targets_main_fork.slurm /path/to/user/fork/of/regional-hydrologic-forcings-ml/
+
+#The intended use is to get targets and file data up to date after a PR is merged.
+#Remember to also update your fork's code with git pull
+################################################################################
+
+module purge
+
+USGS_DIR='/caldera/projects/usgs/water/impd/fhwa/regional-hydrologic-forcings-ml/'
+
+#Checks that the destination target objects are not newer than the newest objects in the source
+#Exits and does not transfer files if they are newer.
+cd $USGS_DIR/'_targets/objects'
+NEWEST_USGS_OBJECT=$(ls -t | head -n1)
+cd $1/'_targets/objects'
+NEWEST_FORK_OBJECT=$(ls -t | head -n1)
+if [ $1'/_targets/objects'/$NEWEST_FORK_OBJECT -nt $USGS_DIR'_targets/objects'/$NEWEST_USGS_OBJECT ]
+then
+    printf '%s\n' "$1 has files that are newer than $USGS_DIR so files are not being copied."
+    exit 1
+fi
+
+#copy _targets folder (using rsync to copy only new targets or updated targets)
+rsync -a $USGS_DIR'/_targets' "$1"
+
+#copy output files (using rsync to copy only new files or updated files)
+rsync -a "$USGS_DIR"'1_fetch/out' $1'/1_fetch/'
+rsync -a "$USGS_DIR"'3_cluster/out' $1'/3_cluster/'
+rsync -a "$USGS_DIR"'5_EDA/out' $1'/5_EDA/'
+rsync -a "$USGS_DIR"'6_predict/out' $1'/6_predict/'


### PR DESCRIPTION
Adds 2 slurm scripts that transfer (sync) the _targets folders and the \*/out/\* folders. One script is for transferring from the USGS main repo to a forked copy of the repo, and another script is for the reverse.

I tested the script to move files from a fork to USGS main and it worked:

```
library(targets)
tar_outdated()
Registered S3 method overwritten by 'quantmod':
  method            from
  as.zoo.data.frame zoo
character(0)
```