### PR TITLE
created function to map residuals and variogram of residuals

### DIFF
--- a/6_predict/src/plot_diagnostics.R
+++ b/6_predict/src/plot_diagnostics.R
@@ -306,7 +306,7 @@ make_residual_map <- function(df_pred_obs, sites_g2_sf, metric, pred_gage_ids, r
     ggtitle(paste("metric= ",metric,"    region = ", region ))
   
   p2 <- plot(variogram(resid ~1, df,
-                       cutoff = 100, 
+                       cutoff = 1000, 
                        width = 2,
                        cressie = TRUE),
              asp=1)

--- a/6_predict/src/plot_diagnostics.R
+++ b/6_predict/src/plot_diagnostics.R
@@ -269,12 +269,11 @@ make_residual_map <- function(df_pred_obs, sites_g2_sf, metric, pred_gage_ids, r
   #' @param df_pred_obs is a data frame with observed (obs) and predicted (.pred) from 
   #' the output of  predict_test_data function. if left null and from_predict is true, 
   #' it will predict it from the model_wf (copied these lines from the plot_pred_obs function)
-  #' @param sites_g2_sf  gagesii spatial ata object with LAT LON and ID
+  #' @param sites_g2_sf  gagesii spatial data object with LAT LON and ID
   #' @param metric  metric that is being predicted
   #' @param pred_gage_ids vector of gage ids that correspond to each row of the df_pred_obs
   #' @param region  region of the model/prediction
   #' @param directory where output figures are saved
-  #' 
 
   if(from_predict){
     #predict from provided workflow and data
@@ -290,30 +289,39 @@ make_residual_map <- function(df_pred_obs, sites_g2_sf, metric, pred_gage_ids, r
     mutate(resid = obs - .pred)
   
   states <- map_data("state")
-  
+  limit <- quantile(df$resid, probs = c( 0.1, 0.9))
   p1<-ggplot(states, aes(x=long, y=lat, group=group)) +
-    geom_polygon(fill="white", colour="gray") +
+    geom_polygon(fill="gray60", colour="gray80") +
     geom_sf(data = df, inherit.aes = FALSE, 
             aes(color = .data[["resid"]]), 
-            size = 0.75)+
-    scale_color_scico(palette = 'batlow')+
+            size = 0.5)+
+    scale_color_scico(palette = 'roma',
+                      midpoint = 0,
+                      limits = limit,
+                      oob = scales::squish)+
     theme(legend.position="bottom",
-          legend.key.size=unit(.5,'cm'))+
+          legend.key.size=unit(.75,'cm'))+
     xlab('Longitude') + 
     ylab('Latitude')+
     ggtitle(paste("metric= ",metric,"    region = ", region ))
   
+  p2 <- plot(variogram(resid ~1, df,
+                       cutoff = 100, 
+                       width = 2,
+                       cressie = TRUE),
+             asp=1)
   
-  p2 <- plot(variogram(resid~1, df))
   
   fname<-paste0(out_dir, "/resid_map_", metric, "_", region, ".png")
   
   save_plot(filename = fname, 
             plot = plot_grid(p1,p2, scale = c(1,.8)),
-            base_width = 8,
+            base_width = 10,
             bg="white")
   
+  
 
+  
 
   return(fname)
 }

--- a/6_predict/src/plot_diagnostics.R
+++ b/6_predict/src/plot_diagnostics.R
@@ -261,6 +261,66 @@ plot_pred_obs <- function(df_pred_obs, metric, region, out_dir,
 }
 
 
+make_residual_map <- function(df_pred_obs, sites_g2_sf, metric, pred_gage_ids, region, out_dir,
+                              from_predict = FALSE, model_wf = NULL, pred_data = NULL){
+  #' @description this function creates maps of residuals (obs - predicted) and a
+  #' variogram plot
+  #' 
+  #' @param df_pred_obs is a data frame with observed (obs) and predicted (.pred) from 
+  #' the output of  predict_test_data function. if left null and from_predict is true, 
+  #' it will predict it from the model_wf (copied these lines from the plot_pred_obs function)
+  #' @param sites_g2_sf  gagesii spatial ata object with LAT LON and ID
+  #' @param metric  metric that is being predicted
+  #' @param pred_gage_ids vector of gage ids that correspond to each row of the df_pred_obs
+  #' @param region  region of the model/prediction
+  #' @param directory where output figures are saved
+  #' 
+
+  if(from_predict){
+    #predict from provided workflow and data
+    df_pred_obs <- predict(model_wf, new_data = pred_data, type = 'numeric') %>%
+      mutate(obs = pred_data[[metric]])
+  }
+  
+  lat_lons<- sites_g2_sf %>%
+    filter(ID %in% pred_gage_ids) %>%
+    select(ID, LAT, LON)
+  
+  df<- bind_cols(lat_lons,df_pred_obs) %>%
+    mutate(resid = obs - .pred)
+  
+  states <- map_data("state")
+  
+  p1<-ggplot(states, aes(x=long, y=lat, group=group)) +
+    geom_polygon(fill="white", colour="gray") +
+    geom_sf(data = df, inherit.aes = FALSE, 
+            aes(color = .data[["resid"]]), 
+            size = 0.75)+
+    scale_color_scico(palette = 'batlow')+
+    theme(legend.position="bottom",
+          legend.key.size=unit(.5,'cm'))+
+    xlab('Longitude') + 
+    ylab('Latitude')+
+    ggtitle(paste("metric= ",metric,"    region = ", region ))
+  
+  
+  p2 <- plot(variogram(resid~1, df))
+  
+  fname<-paste0(out_dir, "/resid_map_", metric, "_", region, ".png")
+  
+  save_plot(filename = fname, 
+            plot = plot_grid(p1,p2, scale = c(1,.8)),
+            base_width = 8,
+            bg="white")
+  
+
+
+  return(fname)
+}
+
+
+
+
 #Residual error boxplots
 # boxplot(p6_test_RF_snow_snow$pred$.pred - p6_test_RF_snow_snow$pred$obs,
 #                    p6_test_RF_rain_snow_snow$pred$.pred - p6_test_RF_rain_snow_snow$pred$obs,

--- a/6_predict/src/train_models.R
+++ b/6_predict/src/train_models.R
@@ -641,7 +641,9 @@ predict_test_data <- function(model_wf, features, cluster_table, metrics_table,
   
   perf_metrics <- metrics(test_preds, truth = 'obs', estimate = '.pred')
 
-  return(list(metric = metric_name, pred = test_preds, metrics = perf_metrics))
+  pred_gage_ids <- features$GAGES_ID
+  
+  return(list(metric = metric_name, pred = test_preds, metrics = perf_metrics, pred_gage_ids=pred_gage_ids))
 }
 
 

--- a/_targets.R
+++ b/_targets.R
@@ -155,7 +155,7 @@ list(
   #create a spatial object 
   tar_target(p1_sites_g2_sf,
              st_as_sf(x = p1_sites_g2, coords = c('LON', 'LAT'), 
-                      remove = FALSE, dim = 'XY', na.fail = TRUE),
+                      crs = st_crs(4326),remove = FALSE, dim = 'XY', na.fail = TRUE),
              deployment = 'main'
   ),
   

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ tar_option_set(packages = c("fasstr", "EflowStats", "dataRetrieval",
                             "sf", "cowplot", "gridGraphics", "stringi",
                             "dendextend", "scico", "tidyverse", "nhdplusTools",
                             "sbtools", "maps", "mapproj", "ranger", "Boruta",
-                            "tidymodels", "doParallel", "vip"),
+                            "tidymodels", "doParallel", "vip", "gstat"),
                imports = c("fasstr", "EflowStats", "dataRetrieval", 
                            "cluster","factoextra", "NbClust", "dendextend",
                            "tidyverse", "ranger", "Boruta", "tidymodels"))
@@ -47,6 +47,7 @@ dir.create('6_predict/out/vip', showWarnings = FALSE)
 dir.create('6_predict/out/hypopt', showWarnings = FALSE)
 dir.create('6_predict/out/split_boxplots', showWarnings = FALSE)
 dir.create('6_predict/out/pred_obs', showWarnings = FALSE)
+
 
 ##Load user defined functions
 source("1_fetch/src/get_nwis_data.R")
@@ -1832,6 +1833,80 @@ list(
                                 out_dir = '6_predict/out'),
              deployment = 'main',
              format = 'file'
-  )
+  ),
+  
+  
+  
+  #####residual maps
+  tar_target(p6_residual_map_RF_rain,
+             make_residual_map(df_pred_obs = p6_test_RF_rain_rain$pred, 
+                               sites_g2_sf = p1_sites_g2_sf, 
+                               metric = p6_test_RF_rain_rain$metric, 
+                               pred_gage_ids = p6_test_RF_rain_rain$pred_gage_id, 
+                               region = "rain", 
+                               out_dir= "6_predict/out/pred_obs/")),
+  
+  tar_target(p6_residual_map_RF_snow,
+             make_residual_map(df_pred_obs = p6_test_RF_snow_snow$pred, 
+                               sites_g2_sf = p1_sites_g2_sf, 
+                               metric = p6_test_RF_snow_snow$metric, 
+                               pred_gage_ids = p6_test_RF_snow_snow$pred_gage_id, 
+                               region = "snow", 
+                               out_dir= "6_predict/out/pred_obs/")),
+  
+  tar_target(p6_residual_map_RF_rain_snow,
+             make_residual_map(df_pred_obs = NULL ,
+                               sites_g2_sf = p1_sites_g2_sf,
+                               metric = p6_Boruta_rain_snow$metric,
+                               pred_gage_ids = p6_Boruta_rain_snow$input_data$split$data$GAGES_ID,
+                               region = "rain_snow",
+                               out_dir = "6_predict/out/pred_obs/",
+                               from_predict = TRUE,
+                               model_wf = p6_train_RF_rain_snow$workflow,
+                               pred_data = p6_Boruta_rain_snow$input_data$split$data)),
+  tar_target(p6_residual_map_RF_rain_snow_exact,
+             make_residual_map(df_pred_obs = NULL ,
+                               sites_g2_sf = p1_sites_g2_sf,
+                               metric = p6_Boruta_rain_snow_exact$metric,
+                               pred_gage_ids = p6_Boruta_rain_snow_exact$input_data$split$data$GAGES_ID,
+                               region = "rain_snow_exact",
+                               out_dir = "6_predict/out/pred_obs/",
+                               from_predict = TRUE,
+                               model_wf = p6_train_RF_rain_snow_exact$workflow,
+                               pred_data = p6_Boruta_rain_snow_exact$input_data$split$data)),
+  
+  tar_target(p6_residual_map_RF_CONUS_g2,
+             make_residual_map(df_pred_obs = NULL ,
+                               sites_g2_sf = p1_sites_g2_sf,
+                               metric = p6_Boruta_CONUS_g2$metric,
+                               pred_gage_ids = p6_Boruta_CONUS_g2$input_data$split$data$GAGES_ID,
+                               region = "CONUS_g2",
+                               out_dir = "6_predict/out/pred_obs/",
+                               from_predict = TRUE,
+                               model_wf = p6_train_RF_CONUS_g2$workflow,
+                               pred_data = p6_Boruta_CONUS_g2$input_data$split$data)),
+  
+  tar_target(p6_residual_map_RF_CONUS_g2_exact,
+             make_residual_map(df_pred_obs = NULL ,
+                               sites_g2_sf = p1_sites_g2_sf,
+                               metric = p6_Boruta_CONUS_g2_exact$metric,
+                               pred_gage_ids = p6_Boruta_CONUS_g2_exact$input_data$split$data$GAGES_ID,
+                               region = "CONUS_g2_exact",
+                               out_dir = "6_predict/out/pred_obs/",
+                               from_predict = TRUE,
+                               model_wf = p6_train_RF_CONUS_g2_exact$workflow,
+                               pred_data = p6_Boruta_CONUS_g2_exact$input_data$split$data)),
+  
+  tar_target(p6_residual_map_RF_CONUS_g2_exact_clust,
+             make_residual_map(df_pred_obs = NULL ,
+                               sites_g2_sf = p1_sites_g2_sf,
+                               metric = p6_Boruta_CONUS_g2_exact_clust$metric,
+                               pred_gage_ids = p6_Boruta_CONUS_g2_exact_clust$input_data$split$data$GAGES_ID,
+                               region = "CONUS_g2_exact_clust",
+                               out_dir = "6_predict/out/pred_obs/",
+                               from_predict = TRUE,
+                               model_wf = p6_train_RF_CONUS_g2_exact_clust$workflow,
+                               pred_data = p6_Boruta_CONUS_g2_exact_clust$input_data$split$data))
+  
   
 ) #end list


### PR DESCRIPTION
Included in this pr:

I changed the predict_test_data function to output the gage_ids where the predicted and observed values are so that I could link it to the gagesii LAT LONs.  

The make_residual_map creates the map of residuals (obs - predicted) and maps them along with a variogram plot.  I wasn't sure if I should standardize the residuals in any way, so for now I haven't.  Can change this if needed.  

I made maps corresponding to each of the pred_obs_scatterplots in the out/pred_obs folder.