### PR TITLE
Automatic correlation + misc. fixes

### DIFF
--- a/1_fetch/src/moving_window_functions.R
+++ b/1_fetch/src/moving_window_functions.R
@@ -1,4 +1,3 @@
-
 calc_moving_window_metrics <- function(site_num, window_length, increment, 
                                      min_yrs_in_window, clean_daily_flow, 
                                      yearType, drainArea_tab, NE_probs, 

--- a/2_flow_metrics.R
+++ b/2_flow_metrics.R
@@ -1,4 +1,3 @@
-
 source("2_flow_metrics/src/calc_HIT.R")
 source("2_flow_metrics/src/calc_FDC.R")
 

--- a/3_cluster.R
+++ b/3_cluster.R
@@ -1,4 +1,3 @@
-
 source("3_cluster/src/seasonal_metric_cluster.R")
 source("3_cluster/src/gage_year_coverage_by_cluster.R")
 

--- a/5_EDA.R
+++ b/5_EDA.R
@@ -59,7 +59,7 @@ p5_targets_list<- list(
                                               "SRL35AG", "SRL45AG",
                                               #Min elevation nearly identical for ACC and CAT
                                               "CAT_ELEV_MIN",
-                                              #Canal ditch cndp better than ACC_CANALDITCH (no 0s)
+                                              #Canal ditch cndp better than CANALDITCH (no 0s)
                                               "TOT_CANALDITCH", "ACC_CANALDITCH",
                                               #storage available everywhere with NID and NORM STORAGE
                                               "strg",
@@ -80,9 +80,8 @@ p5_targets_list<- list(
   tar_target(p5_attr_g2,
              drop_high_corr_ACCTOT(features = p5_screen_attr_g2, 
                                    threshold_corr = 0.9,
+                                   cor_method = 'spearman',
                                    drop_var = 'TOT'),
              deployment = 'main'
   )
-  
-  
 )

--- a/5_EDA/src/EDA_feature_plots.R
+++ b/5_EDA/src/EDA_feature_plots.R
@@ -9,6 +9,8 @@ make_EDA_feature_plots <- function(feature_vars, out_dir) {
   #' 
   #' @return maps and plots to output directory
   
+  filesout <- vector('character', length = length(5:ncol(feature_vars)))
+  
   for (i in 5:ncol(feature_vars)) {
     
     data_to_plot <- select(feature_vars, 1:4, all_of(i)) %>%
@@ -48,6 +50,9 @@ make_EDA_feature_plots <- function(feature_vars, out_dir) {
       suppressWarnings()
     fileout <- file.path(out_dir, paste0(col_name, ".png"))
     save_plot(filename = fileout, combo)
+    
+    filesout[i-4] <- fileout
   }
-  return(out_dir)
+  
+  return(filesout)
 }

--- a/5_EDA/src/select_features.R
+++ b/5_EDA/src/select_features.R
@@ -7,6 +7,7 @@ refine_features <- function(nhdv2_attr, drop_columns){
   #'
   #' @param nhdv2_attr the tbl of static attributes (columns) for each COMID (rows)
   #' @param drop_columns character vector of column names to remove from nhdv2_attr
+  #' using select(!contains())
   #' 
   #' @return Returns a refined nhdv2_attr based on the columns to drop
   
@@ -22,29 +23,26 @@ refine_features <- function(nhdv2_attr, drop_columns){
   return(nhdv2_attr_refined)
 }
 
-drop_high_corr_ACCTOT <- function(features, threshold_corr, drop_var){
+drop_high_corr_ACCTOT <- function(features, threshold_corr, cor_method, drop_var){
   #' 
   #' @description Function to remove ACC or TOT attributes that are highly correlated
-  #' with other attributes.
+  #' with other attributes, and then automatically remove all but one of a set of 
+  #' highly correlated attributes.
   #'
   #' @param features table of static attributes (columns) for each gage. Must have
   #' columns for COMID and GAGES_ID
   #' @param threshold_corr correlation threshold used to drop ACC attributes
+  #' @param cor_method correlation method for cor function
   #' @param drop_var the variable prefix to drop. "ACC" or "TOT"
   #' 
   #' @return Returns features without highly correlated drop_var attributes
   
-  #Correlation matrix
-  cor_mat <- abs(cor(features %>% select(-COMID, -GAGES_ID)))
-  
-  #Find all of the features that are highly correlated
-  high_corr_features <- which(cor_mat >= threshold_corr, arr.ind = T)
-  #Remove diagonal
-  high_corr_features <- high_corr_features[
-    -which(high_corr_features[,1] == high_corr_features[,2]),]
+  high_corr_features <- get_high_corr_features(features %>% 
+                                                 select(-COMID, -GAGES_ID), 
+                                               cor_method, threshold_corr)
   
   #Find where drop_var is highly correlated with other variables and remove
-  names_cor <- colnames(cor_mat)
+  names_cor <- colnames(features)
   remove_vars <- vector('character', length = 0L)
   for(i in 1:nrow(high_corr_features)){
     name <- rownames(high_corr_features)[i]
@@ -71,5 +69,53 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, drop_var){
   #cor_mat <- abs(cor(features[,-c(1,2)] %>% select(-contains('_PPT_'), 
   #-contains('_TAV_'), -contains('WB5100'))))
   
+  
+  #Automatic removal of all other highly correlated features
+  #Correlation matrix for only static features
+  high_corr_features <- get_high_corr_features(features %>% 
+                                                 select(-COMID, -GAGES_ID), 
+                                               cor_method, threshold_corr)
+  while (nrow(high_corr_features) > 0){
+    #randomly select an attribute and remove all correlated attributes
+    tmp_col <- sample(unique(rownames(high_corr_features)), size = 1)
+    tmp_rm <- features %>% 
+      select(-COMID, -GAGES_ID) %>%
+      .[, high_corr_features[rownames(high_corr_features) == tmp_col, 2] %>%
+                             as.numeric()] %>%
+      colnames()
+    
+    features <- features %>% select(-{{tmp_rm}})
+    #Correlation matrix for features without the remove_vars
+    high_corr_features <- get_high_corr_features(features %>% 
+                                                   select(-COMID, -GAGES_ID), 
+                                                 cor_method, threshold_corr)
+  }
+  
   return(features)
+}
+
+
+get_high_corr_features <- function(features, cor_method, threshold_corr){
+  #' 
+  #' @description Function to convert a string from #days #months, #weeks, #years to 
+  #' equivalent number of days 
+  #'
+  #' @param features table of features (columns) for each prediction point (rows).
+  #' @param threshold_corr correlation threshold used to drop attributes.
+  #' Absolute value of correlation is used.
+  #' @param cor_method correlation method for cor function. 
+  #' 
+  #' @return matrix of features that have correlation greater than threshold_corr.
+  #' row and column indicies listed in the matrix correspond to the columns in features.
+  
+  #Correlation matrix
+  cor_mat <- abs(cor(features, method = cor_method))
+  
+  #Find all of the features that are highly correlated
+  high_corr_features <- which(cor_mat >= threshold_corr, arr.ind = T)
+  #Remove diagonal
+  high_corr_features <- high_corr_features[
+    -which(high_corr_features[,1] == high_corr_features[,2]),]
+  
+  return(high_corr_features)
 }

--- a/5_EDA/src/select_features.R
+++ b/5_EDA/src/select_features.R
@@ -35,7 +35,7 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, drop_var){
   #' @return Returns features without highly correlated drop_var attributes
   
   #Correlation matrix
-  cor_mat <- cor(features %>% select(-COMID, -GAGES_ID))
+  cor_mat <- abs(cor(features %>% select(-COMID, -GAGES_ID)))
   
   #Find all of the features that are highly correlated
   high_corr_features <- which(cor_mat >= threshold_corr, arr.ind = T)
@@ -62,14 +62,14 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, drop_var){
   features <- select(features, -{{remove_vars}})
   
   #other correlations were checked manually using
-  #cor_mat <- cor(features %>% select(starts_with('CAT_')))
+  #cor_mat <- abs(cor(features %>% select(starts_with('CAT_'))))
   #high_corr_features <- which(cor_mat >= 0.9, arr.ind = T)
   #high_corr_features <- rownames(high_corr_features[
   #  -which(high_corr_features[,1] == high_corr_features[,2]),])
   
   #Then the interaction of CAT and ACC/TOT for non-climate variables:
-  #cor_mat <- cor(features[,-c(1,2)] %>% select(-contains('_PPT_'), 
-  #-contains('_TAV_'), -contains('WB5100')))
+  #cor_mat <- abs(cor(features[,-c(1,2)] %>% select(-contains('_PPT_'), 
+  #-contains('_TAV_'), -contains('WB5100'))))
   
   return(features)
 }

--- a/5_EDA/src/select_features.R
+++ b/5_EDA/src/select_features.R
@@ -76,8 +76,8 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, cor_method, drop_var
                                                  select(-COMID, -GAGES_ID), 
                                                cor_method, threshold_corr)
   while (nrow(high_corr_features) > 0){
-    #randomly select an attribute and remove all correlated attributes
-    tmp_col <- sample(unique(rownames(high_corr_features)), size = 1)
+    #select the first attribute and remove all correlated attributes
+    tmp_col <- unique(rownames(high_corr_features))[1]
     tmp_rm <- features %>% 
       select(-COMID, -GAGES_ID) %>%
       .[, high_corr_features[rownames(high_corr_features) == tmp_col, 2] %>%
@@ -114,8 +114,8 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, cor_method, drop_var
 
 get_high_corr_features <- function(features, cor_method, threshold_corr){
   #' 
-  #' @description Function to convert a string from #days #months, #weeks, #years to 
-  #' equivalent number of days 
+  #' @description Function to get a matrix of highly correlated features from the
+  #' supplied features table
   #'
   #' @param features table of features (columns) for each prediction point (rows).
   #' @param threshold_corr correlation threshold used to drop attributes.

--- a/5_EDA/src/select_features.R
+++ b/5_EDA/src/select_features.R
@@ -84,6 +84,23 @@ drop_high_corr_ACCTOT <- function(features, threshold_corr, cor_method, drop_var
                              as.numeric()] %>%
       colnames()
     
+    #Check if the drop_var prefix is used by tmp_col.
+    if(substr(tmp_col, 1,3) == drop_var){
+      #Check if the same suffix is within tmp_rm
+      tmp_rm_mat <- as.matrix(tmp_rm, ncol = 1, nrow = length(tmp_rm))
+      suffix <- apply(X = tmp_rm_mat, MARGIN = 1, FUN = substr, 4, max(nchar(tmp_rm_mat)))
+      
+      if(substr(tmp_col, 4, nchar(tmp_col)) %in% suffix){
+        #switch the tmp_col to the drop_var prefix variable
+        tmp_col <- tmp_rm[suffix %in%  substr(tmp_col, 4, nchar(tmp_col))]
+        tmp_rm <- features %>% 
+          select(-COMID, -GAGES_ID) %>%
+          .[, high_corr_features[rownames(high_corr_features) == tmp_col, 2] %>%
+              as.numeric()] %>%
+          colnames()
+      }
+    }
+    
     features <- features %>% select(-{{tmp_rm}})
     #Correlation matrix for features without the remove_vars
     high_corr_features <- get_high_corr_features(features %>% 

--- a/6_predict.R
+++ b/6_predict.R
@@ -1,4 +1,3 @@
-
 source("6_predict/src/train_models.R")
 source("6_predict/src/plot_diagnostics.R")
 
@@ -1057,8 +1056,5 @@ p6_targets_list<- list(
                                from_predict = TRUE,
                                model_wf = p6_train_RF_CONUS_g2_exact_clust$workflow,
                                pred_data = p6_Boruta_CONUS_g2_exact_clust$input_data$split$data))
-  
-  
-  
   
 )

--- a/6_predict/src/plot_diagnostics.R
+++ b/6_predict/src/plot_diagnostics.R
@@ -319,15 +319,9 @@ make_residual_map <- function(df_pred_obs, sites, metric, pred_gage_ids, region,
             plot = plot_grid(p1,p2, scale = c(1,.8)),
             base_width = 10,
             bg="white")
-  
-  
-
-  
 
   return(fname)
 }
-
-
 
 
 #Residual error boxplots


### PR DESCRIPTION
Adds automatic screening of highly correlated features based on a supplied correlation threshold. I implemented rank correlation with a 0.9 threshold. This is the major edit for this PR within `select_features.R`. With this screening, the features are only CAT and ACC, and the total number of features available for prediction is 169.

Question: I implemented preferential dropping of TOT attributes when there was an ACC attribute that was highly correlated with it. Do we have a similar preference for retaining ACC vs. CAT attributes? That preference can also be added to the automatic screening.
Closes: #116

Edits one file target to return filepaths instead of the output directory. I checked all file targets for this issue and only one needed to be edited.
Closes #146

Adds absolute value to correlation screening.
Closes #132 



I updated all targets except p6 (predict) because those take a while and I think there will be upcoming edits that also affect those prediction targets.