### PR TITLE
removed NA and -9998 from NHD data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -320,5 +320,11 @@ p1_targets_list <- list(
                                                "TotDASqKM", "DivDASqKM", "SLOPE", 
                                                "LakeFract", "SurfArea")), 
              deployment = "main"
-  )
+  ),
+  
+  ##screening out NA and -9998, -9999 values
+  tar_target(p1_feature_vars_conus_screen,
+             p1_feature_vars_conus %>%
+               na.exclude() %>%
+               filter_if(is.numeric, all_vars(. > -990)))
 )


### PR DESCRIPTION
Very quick change for issue #187  to screen out reaches that had NAs in their feature values.  There were also a handful of features that had values of -9998 or -9999 so I removed those rows as well.


feature with  -9998 or -9999 values:
 [1] "ACC_STREAM_SLOPE" "TOT_STREAM_SLOPE" "ACC_HGA"          "ACC_HGAC"         "ACC_HGAD"        
 [6] "ACC_HGB"          "ACC_HGBC"         "ACC_HGBD"         "ACC_HGC"          "ACC_HGCD"        
[11] "ACC_HGD"          "ACC_HGVAR"        "CAT_HGA"          "CAT_HGAC"         "CAT_HGAD"        
[16] "CAT_HGB"          "CAT_HGBC"         "CAT_HGBD"         "CAT_HGC"          "CAT_HGCD"        
[21] "CAT_HGD"          "CAT_HGVAR"        "TOT_HGA"          "TOT_HGAC"         "TOT_HGAD"        
[26] "TOT_HGB"          "TOT_HGBC"         "TOT_HGBD"         "TOT_HGC"          "TOT_HGCD"        
[31] "TOT_HGD"          "TOT_HGVAR"        "ACC_SRL25AG"      "ACC_SRL35AG"      "ACC_SRL45AG"     
[36] "ACC_SRL55AG"      "CAT_SRL25AG"      "CAT_SRL35AG"      "CAT_SRL45AG"      "CAT_SRL55AG"     
[41] "TOT_SRL25AG"      "TOT_SRL35AG"      "TOT_SRL45AG"      "TOT_SRL55AG"      "CAT_RECHG"       
[46] "ACC_RECHG"        "TOT_RECHG"        "CAT_EWT"          "ACC_EWT"          "TOT_EWT"  